### PR TITLE
Prevent auto initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,7 @@ A jQuery plugin that enables <key>⌘</key>/<key>ctrl</key> + <key>enter</key> t
 
 ## Usage
 
-Include `cmd-ctrl-enter.js` script. Then add the following markup:
-
-    <textarea class="cmd-ctrl-enter"></textarea>
-
-That’s it! Alternatively, do it manually:
+Include `cmd-ctrl-enter.js` script. Then select your textareas, and call `cmdCtrlEnter`:
 
     $('textarea').cmdCtrlEnter();
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cmd-ctrl-enter",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "A jQuery plugin that enables `⌘`/`ctrl` + `enter` to submit a form (when applied to a textarea).",
   "keywords": [
     "library"

--- a/src/cmd-ctrl-enter.js
+++ b/src/cmd-ctrl-enter.js
@@ -18,8 +18,4 @@
     });
     return this;
   };
-
-  $(function() {
-    $('textarea.cmd-ctrl-enter').cmdCtrlEnter();
-  });
 })(jQuery);

--- a/src/cmd-ctrl-enter.js
+++ b/src/cmd-ctrl-enter.js
@@ -1,21 +1,23 @@
 (function($) {
+  var nav = window.navigator;
+  var mac = 'platform' in nav && (/^Mac/).test(nav.platform);
+
   $.fn.cmdCtrlEnter = function(o) {
-
-    var nav = window.navigator,
-        mac = 'platform' in nav && (/^Mac/).test(nav.platform);
-
     if(o === 'which') return mac ? '⌘' : 'Ctrl';
-
     if(o === 'destroy') return this.unbind('keydown.cmdCtrlEnter');
 
     this.filter('textarea').each(function(i, el) {
-      var $el = $(el), $form = $el.parents('form'), $btn = $form.find('[type=submit]');
+      var $el = $(el);
+      var $form = $el.parents('form');
+      var $btn = $form.find('[type=submit]');
 
       $el.on('keydown.cmdCtrlEnter', function(evt) {
-        if(evt.which === 13 && ((evt.ctrlKey && !mac) || evt.metaKey))
+        if(evt.which === 13 && ((evt.ctrlKey && !mac) || evt.metaKey)) {
           if(!$btn.attr('disabled')) $form.submit();
+        }
       });
     });
+
     return this;
   };
 })(jQuery);


### PR DESCRIPTION
When using something like Turbolinks, the document ready function is not always called on page change. This PR removes the auto-initialisation, leaving that up to the developer. It also improves the code formatting.
